### PR TITLE
Remove fork policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ Blocklist of Soapbox instances in Mastodon import format.
 
 List of instances that have been removed from the blocklist, with reasons for removal. Not importable into Mastodon.
 
-## Policy
-
-The sole criteria for inclusion on this list is use of the Soapbox backend or frontend. Instances that migrate to a hard fork of Soapbox which no longer cooperates with the original developer will eventually be removed. Known hard forks:
-
-- [Mangane](https://github.com/BDX-town/Mangane)
-
 ## Verifying the list
 
 The comment for each entry on the list contains the domain on which Soapbox was detected. You can visit that domain in a browser or check its [NodeInfo](https://github.com/jhass/nodeinfo) to verify that it is, in fact, running Soapbox. Note that it may be a subdomain of the blocked domain; this is common for instances running Soapbox as an alternate frontend to another Fediverse server.


### PR DESCRIPTION
I believe omitting certain forks from this list is a mistake. The fact is, if you are neutral in situations of injustice, you have chosen the side of the oppressor. You cannot separate the software from the author. It's the paradox of tolerance. The people running those forks are complicit in transphobia and genocide and must be stopped.